### PR TITLE
LPS-60842

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/LayoutImportController.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/controller/LayoutImportController.java
@@ -23,6 +23,9 @@ import static com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleCon
 import static com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleConstants.PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS;
 import static com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleConstants.PROCESS_FLAG_LAYOUT_STAGING_IN_PROCESS;
 
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.exportimport.kernel.controller.ExportImportController;
 import com.liferay.exportimport.kernel.controller.ImportController;
 import com.liferay.exportimport.kernel.exception.LARFileException;
@@ -30,6 +33,7 @@ import com.liferay.exportimport.kernel.exception.LARTypeException;
 import com.liferay.exportimport.kernel.exception.LayoutImportException;
 import com.liferay.exportimport.kernel.exception.MissingReferenceException;
 import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportProcessCallbackRegistryUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
 import com.liferay.exportimport.kernel.lar.MissingReference;
@@ -103,6 +107,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import org.apache.commons.lang.time.StopWatch;
 
@@ -224,6 +229,15 @@ public class LayoutImportController implements ImportController {
 				PortletDataContextFactoryUtil.clonePortletDataContext(
 					portletDataContext),
 				userId);
+
+			Map<Long, Long> folderIdPairs =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					DLFolder.class);
+
+			if (!folderIdPairs.isEmpty()) {
+				ExportImportProcessCallbackRegistryUtil.registerCallback(
+					new CascadeFileEntryTypesCallable(folderIdPairs));
+			}
 		}
 		catch (Throwable t) {
 			ExportImportThreadLocal.setLayoutImportInProcess(false);
@@ -1462,6 +1476,51 @@ public class LayoutImportController implements ImportController {
 		if (!missingLayoutPrototypes.isEmpty()) {
 			throw new LayoutPrototypeException(missingLayoutPrototypes);
 		}
+	}
+
+	private class CascadeFileEntryTypesCallable implements Callable<Void> {
+		public CascadeFileEntryTypesCallable(Map<Long, Long> folderIdPairs) {
+			_folderIdPairs = folderIdPairs;
+		}
+
+		@Override
+		public Void call() throws PortalException {
+			_checkedFolders = new HashSet<DLFolder>();
+
+			for(Long newFolderId : _folderIdPairs.values()) {
+				DLFolder newFolder =
+					DLFolderLocalServiceUtil.fetchDLFolder(newFolderId);
+
+				DLFolder rootFolder = getProcessableRootFolder(newFolder);
+
+				if(Validator.isNotNull(rootFolder)) {
+					DLFileEntryTypeLocalServiceUtil.cascadeFileEntryTypes(
+						rootFolder.getUserId(), rootFolder);
+				}
+			}
+
+			return null;
+		}
+
+		protected DLFolder getProcessableRootFolder(DLFolder folder)
+			throws PortalException {
+
+			if(_checkedFolders.contains(folder)) {
+				return null;
+			}
+
+			_checkedFolders.add(folder);
+			DLFolder parentFolder = folder.getParentFolder();
+
+			if(Validator.isNull(parentFolder)) {
+				return folder;
+			}
+
+			return getProcessableRootFolder(parentFolder);
+		}
+
+		private Set<DLFolder> _checkedFolders;
+		private final Map<Long, Long> _folderIdPairs;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -859,8 +859,10 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 					description, defaultFileEntryTypeId, fileEntryTypeIds,
 					restrictionType, serviceContext);
 
-				dlFileEntryTypeLocalService.cascadeFileEntryTypes(
-					serviceContext.getUserId(), dlFolder);
+				if (!ExportImportThreadLocal.isImportInProcess()){
+					dlFileEntryTypeLocalService.cascadeFileEntryTypes(
+						serviceContext.getUserId(), dlFolder);
+				}
 			}
 
 			// Workflow definitions


### PR DESCRIPTION
Hi Giros

This fix registers the cascadeFileEntryTypes() method to PortalImportController and LayoutImportController. Thus in case of import, the recursive cascadeFileEntryTypes() method is not going to be called over and over again on the same branch of folders.

Regards,
Adorján