### PR TITLE
LPS-72312 Page icons are not rendered in the Navigation Menu

### DIFF
--- a/util-taglib/src/com/liferay/taglib/theme/LayoutIconTag.java
+++ b/util-taglib/src/com/liferay/taglib/theme/LayoutIconTag.java
@@ -69,7 +69,7 @@ public class LayoutIconTag
 			jspWriter.write(themeDisplay.getPathImage());
 
 			jspWriter.write("/layout_icon?img_id=");
-			jspWriter.write(String.valueOf(layout.getIconImage()));
+			jspWriter.write(String.valueOf(layout.getIconImageId()));
 			jspWriter.write("&t=");
 			jspWriter.write(
 				WebServerServletTokenUtil.getToken(layout.getIconImageId()));


### PR DESCRIPTION
Hi Giros,

LPS-70911 causes this issue and LPS-72010 was created to solve it, however it solves it partially (the icon is still not displayed).
As LPS-72010 is committed and backported and released in fixpack, I created a new LPS.

You can find every details on the LPS: https://issues.liferay.com/browse/LPS-72312

Thanks,
