### PR TITLE
LPS-72207 - Cannot link the URL of Web Content management page to a Web Content.

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
@@ -1226,6 +1227,12 @@ public class BaseTextExportImportContentProcessor
 			if (endPos != -1) {
 				url = url.substring(0, endPos);
 			}
+
+			String siteAdminURL =
+				group.getFriendlyURL() +
+					VirtualLayoutConstants.CANONICAL_URL_SEPARATOR;
+
+			url = url.replaceAll(siteAdminURL, StringPool.BLANK);
 
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);


### PR DESCRIPTION
Hey @danielkocsis,

I have tried to create the test by adding a link in "layout_references.txt", but I still wonder if it is possible. let me explain here.

currently, the site admin works against the below two URLs, the only differences is that. we use '/~' to differentiate whether it is a site admin URL. if we allow exporting a URL contains "/~",  then my fix is just to make it pass the basic validation.

"http://localhost:8080/group/control_panel/manage?p_p_id=com_liferay_wiki_web_portlet_WikiAdminPortlet"

"http://localhost:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_wiki_web_portlet_WikiAdminPortlet" 

I hope you can continue to review the PR, for the following reason.
1: LPP has been kept for a while.  I met the problem in writing the test case.

2: Normal I would create the test case, but currently export and import do not work related to "CONTROL PANEL".


Thanks,
David.