### PR TITLE
[TECHNICAL-SUPPORT] LPS-73907 There is no need to check all the rating entries during pro…

### DIFF
--- a/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/internal/page/ratings/exportimport/data/handler/PageRatingsPortletDataHandler.java
+++ b/modules/apps/collaboration/ratings/ratings-service/src/main/java/com/liferay/ratings/internal/page/ratings/exportimport/data/handler/PageRatingsPortletDataHandler.java
@@ -24,6 +24,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerBoolean;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
@@ -90,7 +91,8 @@ public class PageRatingsPortletDataHandler extends BasePortletDataHandler {
 		Element rootElement = addExportDataRootElement(portletDataContext);
 
 		if (!portletDataContext.getBooleanParameter(
-				NAMESPACE, "ratings-entries")) {
+				NAMESPACE, "ratings-entries") ||
+			MergeLayoutPrototypesThreadLocal.isInProgress()) {
 
 			return getExportDataRootElementString(rootElement);
 		}


### PR DESCRIPTION
…pagation. At Site creation, all the contents are exported/imported, therefore the rating entries are handled as well.