### PR TITLE
[TECHNICAL-SUPPORT] LPS-94690 Async status monitoring for remote staging

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -1925,6 +1925,12 @@ public class StagingImpl implements Staging {
 				remoteSiteURL.getProtocol(), remoteAddress,
 				remoteSiteURL.getPort(), remoteSiteURL.getFile());
 
+			typeSettingsProperties.setProperty(
+				"remoteURL", remoteSiteURL.toString());
+
+			_groupLocalService.updateGroup(
+				stagingGroup.getGroupId(), typeSettingsProperties.toString());
+
 			return remoteSiteURL.toString();
 		}
 		catch (MalformedURLException murle) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -1928,6 +1928,9 @@ public class StagingImpl implements Staging {
 			typeSettingsProperties.setProperty(
 				"remoteURL", remoteSiteURL.toString());
 
+			typeSettingsProperties.setProperty(
+				"lastUpdate", String.valueOf(System.currentTimeMillis()));
+
 			_groupLocalService.updateGroup(
 				stagingGroup.getGroupId(), typeSettingsProperties.toString());
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -180,9 +181,19 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 			UnicodeProperties typeSettingsProperties =
 				group.getTypeSettingsProperties();
 
+			long lastUpdate = GetterUtil.getLong(
+				typeSettingsProperties.getProperty("lastUpdate"));
+
 			try {
-				_liveGroupURL = StagingUtil.getRemoteSiteURL(
-					group, layout.isPrivateLayout());
+				if ((System.currentTimeMillis() - lastUpdate) >=
+						PropsValues.STAGING_REMOTE_URL_TIMEOUT) {
+
+					_liveGroupURL = StagingUtil.getRemoteSiteURL(
+						group, layout.isPrivateLayout());
+
+					typeSettingsProperties.setProperty(
+						"remoteURL", _liveGroupURL);
+				}
 
 				typeSettingsProperties.setProperty("remoteConnection", null);
 			}
@@ -206,6 +217,8 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 							cause.getMessage());
 				}
 
+				typeSettingsProperties.setProperty(
+					"lastUpdate", String.valueOf(System.currentTimeMillis()));
 				typeSettingsProperties.setProperty(
 					"remoteConnection", Boolean.FALSE.toString());
 			}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -212,6 +212,8 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 
 			GroupLocalServiceUtil.updateGroup(
 				group.getGroupId(), typeSettingsProperties.toString());
+
+			_liveGroupURL = typeSettingsProperties.getProperty("remoteURL");
 		}
 		else if (group.isStagingGroup()) {
 			Group liveGroup = StagingUtil.getLiveGroup(group.getGroupId());

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -29,14 +29,10 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.application.list.PanelAppRegistry" %><%@
 page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%@
-page import="com.liferay.exportimport.kernel.exception.RemoteExportException" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.ItemSelectorCriterion" %><%@
 page import="com.liferay.item.selector.criteria.URLItemSelectorReturnType" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.exception.SystemException" %><%@
-page import="com.liferay.portal.kernel.log.Log" %><%@
-page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -20,9 +20,11 @@
 PanelCategory panelCategory = (PanelCategory)request.getAttribute(ApplicationListWebKeys.PANEL_CATEGORY);
 
 SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDisplayContext = new SiteAdministrationPanelCategoryDisplayContext(liferayPortletRequest, liferayPortletResponse, null);
+
+Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 %>
 
-<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getGroup() != null %>">
+<c:if test="<%= group != null %>">
 	<div class="row">
 		<div class="col-md-12">
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() %>">
@@ -42,22 +44,18 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 					<%
 					data.put("qa-id", "live");
 
-					try {
-						String liveGroupURL = siteAdministrationPanelCategoryDisplayContext.getLiveGroupURL();
+					String liveGroupURL = siteAdministrationPanelCategoryDisplayContext.getLiveGroupURL();
+
+					String remoteConnection = group.getTypeSettingsProperty("remoteConnection");
 					%>
 
+					<c:if test="<%= Validator.isNull(remoteConnection) %>">
 						<span class="<%= Validator.isNull(liveGroupURL) ? "active" : StringPool.BLANK %>">
 							<aui:a data="<%= data %>" href="<%= liveGroupURL %>" label="<%= siteAdministrationPanelCategoryDisplayContext.getLiveGroupLabel() %>" />
 						</span>
+					</c:if>
 
-					<%
-					}
-					catch (RemoteExportException | SystemException e) {
-						if (e instanceof SystemException) {
-							_log.error(e, e);
-						}
-					%>
-
+					<c:if test="<%= Validator.isNotNull(remoteConnection) && group.isStagedRemotely() %>">
 						<aui:a data="<%= data %>" href="" id="remoteLiveLink" label="<%= siteAdministrationPanelCategoryDisplayContext.getLiveGroupLabel() %>" />
 
 						<aui:script use="aui-tooltip">
@@ -71,11 +69,7 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 								}
 							).render();
 						</aui:script>
-
-					<%
-					}
-					%>
-
+					</c:if>
 				</div>
 			</c:if>
 
@@ -91,7 +85,3 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 		/>
 	</c:if>
 </c:if>
-
-<%!
-private static Log _log = LogFactoryUtil.getLog("com_liferay_product_navigation_site_administration.sites.site_administration_body_jsp");
-%>

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -3041,6 +3041,10 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED));
 
+	public static final long STAGING_OWNER_REMOTE_URL_LOCK_TIMEOUT =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.STAGING_OWNER_REMOTE_URL_LOCK_TIMEOUT));
+
 	public static final int STAGING_REMOTE_TRANSFER_BUFFER_SIZE =
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.STAGING_REMOTE_TRANSFER_BUFFER_SIZE));

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -3049,6 +3049,9 @@ public class PropsValues {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.STAGING_REMOTE_TRANSFER_BUFFER_SIZE));
 
+	public static final long STAGING_REMOTE_URL_TIMEOUT = GetterUtil.getLong(
+		PropsUtil.get(PropsKeys.STAGING_REMOTE_URL_TIMEOUT));
+
 	public static final int STAGING_SYSTEM_EVENT_CHECK_INTERVAL =
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.STAGING_SYSTEM_EVENT_CHECK_INTERVAL));

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -458,6 +458,8 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			"branchingPrivate", String.valueOf(branchingPrivate));
 		typeSettingsProperties.setProperty(
 			"branchingPublic", String.valueOf(branchingPublic));
+		typeSettingsProperties.setProperty(
+			"lastUpdate", String.valueOf(System.currentTimeMillis()));
 		typeSettingsProperties.setProperty("remoteAddress", remoteAddress);
 		typeSettingsProperties.setProperty(
 			"remoteGroupId", String.valueOf(remoteGroupId));

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingLocalServiceImpl.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.security.auth.RemoteAuthException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -438,6 +439,21 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			userId, stagingGroup, branchingPublic, branchingPrivate, true,
 			serviceContext);
 
+		String groupDisplayURL = null;
+
+		if ((serviceContext != null) &&
+			(serviceContext.getThemeDisplay() != null)) {
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			Layout layout = themeDisplay.getLayout();
+
+			boolean privateLayout = layout.isPrivateLayout();
+
+			groupDisplayURL = GroupServiceHttp.getGroupDisplayURL(
+				httpPrincipal, remoteGroupId, privateLayout, secureConnection);
+		}
+
 		typeSettingsProperties.setProperty(
 			"branchingPrivate", String.valueOf(branchingPrivate));
 		typeSettingsProperties.setProperty(
@@ -451,6 +467,7 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 			"remotePathContext", remotePathContext);
 		typeSettingsProperties.setProperty(
 			"remotePort", String.valueOf(remotePort));
+		typeSettingsProperties.setProperty("remoteURL", groupDisplayURL);
 		typeSettingsProperties.setProperty(
 			"secureConnection", String.valueOf(secureConnection));
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9053,6 +9053,15 @@
     staging.live.group.remote.staging.enabled=false
 
     #
+    # Set the lock timeout for when a user requests the staging's remote URL.
+    # This prevents multiple users from requesting/building the remote URL.
+    # The value is interpreted as milliseconds.
+    #
+    # Env: LIFERAY_STAGING_PERIOD_OWNER_PERIOD_REMOTE_PERIOD_URL_PERIOD_LOCK_PERIOD_TIMEOUT
+    #
+    staging.owner.remote.url.lock.timeout=10000
+
+    #
     # Set the file block sizes for remote staging. If a LAR file used for remote
     # staging exceeds this size, the file will be split into multiple files
     # prior to transmission and then reassembled on the remote server. The

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9072,6 +9072,14 @@
     staging.remote.transfer.buffer.size=10485760
 
     #
+    # Set the validity timeout from requesting the remote staging's URL. The
+    # value is interpreted as milliseconds.
+    #
+    # Env: LIFERAY_STAGING_PERIOD_REMOTE_PERIOD_URL_PERIOD_TIMEOUT
+    #
+    staging.remote.url.timeout=3600000
+
+    #
     # Set the interval in hours on how often CheckSystemEventMessageListener
     # will run to check for and delete system events that have been reached the
     # maximum age.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3460,6 +3460,9 @@ public interface PropsKeys {
 	public static final String STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED =
 		"staging.live.group.remote.staging.enabled";
 
+	public static final String STAGING_OWNER_REMOTE_URL_LOCK_TIMEOUT =
+		"staging.owner.remote.url.lock.timeout";
+
 	public static final String STAGING_REMOTE_TRANSFER_BUFFER_SIZE =
 		"staging.remote.transfer.buffer.size";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3466,6 +3466,9 @@ public interface PropsKeys {
 	public static final String STAGING_REMOTE_TRANSFER_BUFFER_SIZE =
 		"staging.remote.transfer.buffer.size";
 
+	public static final String STAGING_REMOTE_URL_TIMEOUT =
+		"staging.remote.url.timeout";
+
 	public static final String STAGING_SYSTEM_EVENT_CHECK_INTERVAL =
 		"staging.system.event.check.interval";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.10.0
+version 9.11.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94690

Previous pr: https://github.com/moltam89/liferay-portal/pull/504
Changes due to [PTR-1005 discussion](https://issues.liferay.com/browse/PTR-1005?focusedCommentId=1925083&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1925083).

The issue is when the site is staging. At every page load of the Control Panel, the local server would send a request to the remote server. This can cause the site to hang because the request is sent in GroupServiceHttp.getGroupDisplayURL. The timeout can take 30 seconds.

The solution is to cache the result for Remote Staging, when the Control Panel is navigated (based on last-updated-time type of approach). The groupDisplayURL will be cached for each staged site and stored within the TypeSettings. If Control Panel is navigated and the last-updated-time is still relevant, we will provide the cached remote URL. If the cached value is expired, user would request the URL and cache the value again. 

Race-conditions are handled by utilizing a strategy that is being used for merging layoutset prototypes in [SitesImpl.java#L1319](https://github.com/liferay/liferay-portal/blob/7.2.0-ga1/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java#L1319).